### PR TITLE
Phonies the build target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+.PHONY: build
 build:
 	go build -o bin/kv
 	go build -o bin/client client/cmd/main.go


### PR DESCRIPTION
    Changes:
            1. Adds a .PHONY to the build target so that GNU make doesn't confuse it with the build directory