### PR TITLE
Fix FindLeader to return ip:port. 

### DIFF
--- a/coordinator/helpers.go
+++ b/coordinator/helpers.go
@@ -54,7 +54,7 @@ func (c *Coordinator) FindLeader(key string) (string, int64, error) {
 		leader, err := c.Leader(nodeAddr)
 
 		if err == nil && leader != "" {
-			return leader, shardID, nil
+			return nodeAddr, shardID, nil
 		}
 	}
 	return "", -1, fmt.Errorf("shard %d is not reachable", shardID)


### PR DESCRIPTION
This used to work previously because everything was on the same machine. Now we need IP:port.